### PR TITLE
Fix file type errors

### DIFF
--- a/lib/file_upload_service.dart
+++ b/lib/file_upload_service.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+class FileUploadService {
+  static Future<File?> pickImageFile() async {
+    try {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        type: FileType.image,
+        allowMultiple: false,
+      );
+
+      if (result != null && result.files.single.path != null) {
+        return File(result.files.single.path!);
+      }
+    } catch (e) {
+      debugPrint('Error picking image file: $e');
+    }
+    return null;
+  }
+
+  static Future<File?> pickCustomFile({
+    required List<String> allowedExtensions,
+  }) async {
+    try {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: allowedExtensions,
+        allowMultiple: false,
+      );
+
+      if (result != null && result.files.single.path != null) {
+        return File(result.files.single.path!);
+      }
+    } catch (e) {
+      debugPrint('Error picking custom file: $e');
+    }
+    return null;
+  }
+
+  static Future<List<File>> pickMultipleFiles() async {
+    try {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        allowMultiple: true,
+      );
+
+      if (result != null) {
+        return result.paths
+            .where((path) => path != null)
+            .map((path) => File(path!))
+            .toList();
+      }
+    } catch (e) {
+      debugPrint('Error picking multiple files: $e');
+    }
+    return [];
+  }
+
+  static Future<File?> pickAnyFile() async {
+    try {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        type: FileType.any,
+        allowMultiple: false,
+      );
+
+      if (result != null && result.files.single.path != null) {
+        return File(result.files.single.path!);
+      }
+    } catch (e) {
+      debugPrint('Error picking any file: $e');
+    }
+    return null;
+  }
+
+  static Future<File?> pickVideoFile() async {
+    try {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        type: FileType.video,
+        allowMultiple: false,
+      );
+
+      if (result != null && result.files.single.path != null) {
+        return File(result.files.single.path!);
+      }
+    } catch (e) {
+      debugPrint('Error picking video file: $e');
+    }
+    return null;
+  }
+
+  static Future<File?> pickAudioFile() async {
+    try {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        type: FileType.audio,
+        allowMultiple: false,
+      );
+
+      if (result != null && result.files.single.path != null) {
+        return File(result.files.single.path!);
+      }
+    } catch (e) {
+      debugPrint('Error picking audio file: $e');
+    }
+    return null;
+  }
+
+  static Future<File?> pickDocumentFile() async {
+    try {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['pdf', 'doc', 'docx', 'txt', 'rtf'],
+        allowMultiple: false,
+      );
+
+      if (result != null && result.files.single.path != null) {
+        return File(result.files.single.path!);
+      }
+    } catch (e) {
+      debugPrint('Error picking document file: $e');
+    }
+    return null;
+  }
+
+  static String getFileExtension(String filePath) {
+    return filePath.split('.').last.toLowerCase();
+  }
+
+  static String getFileName(String filePath) {
+    return filePath.split('/').last;
+  }
+
+  static bool isImageFile(String filePath) {
+    final extension = getFileExtension(filePath);
+    return ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'].contains(extension);
+  }
+
+  static bool isVideoFile(String filePath) {
+    final extension = getFileExtension(filePath);
+    return ['mp4', 'avi', 'mov', 'mkv', 'wmv', 'flv', 'webm'].contains(extension);
+  }
+
+  static bool isAudioFile(String filePath) {
+    final extension = getFileExtension(filePath);
+    return ['mp3', 'wav', 'aac', 'ogg', 'flac', 'm4a'].contains(extension);
+  }
+
+  static bool isDocumentFile(String filePath) {
+    final extension = getFileExtension(filePath);
+    return ['pdf', 'doc', 'docx', 'txt', 'rtf', 'xls', 'xlsx', 'ppt', 'pptx'].contains(extension);
+  }
+}


### PR DESCRIPTION
<!-- Add FileUploadService to update `file_picker` API usage and resolve build errors. -->

The previous build failed due to `FileType.custom` and `FileType.any` not being found, indicating an outdated `file_picker` API. This PR introduces a new service (`lib/file_upload_service.dart`) that correctly implements the modern `file_picker` API, including proper handling for `FileType.custom` with `allowedExtensions` and `FileType.any`, along with utility methods for various file types and error handling.